### PR TITLE
Adjust fragment shaders to compile against Qt 5.9 beta2

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -110,13 +110,13 @@ Rectangle {
 
                 if (wobbleEnabled) {
                     fragmentShaderText +=
-                        "highp vec2 wobbleCoords(vec2 coords) {\n" +
+                        "highp vec2 wobbleCoords(highp vec2 coords) {\n" +
                         "   return coords + wobbleFactor * vec2(0.05 * sin(1.0 * cos(25.0 * (coords.y * coords.y + 0.25 * time))), 0.03 * sin(1.0 * cos(7.0 * (coords.x + 0.23 * time))));\n" +
                         "}\n";
                 }
 
                 if (wobbleEnabled || hologramEnabled) {
-                    fragmentShaderText += "highp vec4 sample(vec2 coords) {\n";
+                    fragmentShaderText += "highp vec4 sample(highp vec2 coords) {\n";
 
                     if (hologramEnabled) {
                         fragmentShaderText +=
@@ -140,7 +140,7 @@ Rectangle {
                     fragmentShaderText += "}\n";
                 } else {
                     fragmentShaderText +=
-                        "highp vec4 sample(vec2 coords) {\n" +
+                        "highp vec4 sample(highp vec2 coords) {\n" +
                         "   return texture2D(source, coords);\n" +
                         "}\n";
                 }


### PR DESCRIPTION
I was interestingly enough getting:

*** Problematic Fragment shader source code ***
#ifndef GL_FRAGMENT_PRECISION_HIGH
#define highp mediump
#endif
#line 1
uniform lowp sampler2D source;
uniform lowp float qt_Opacity;
uniform highp float time;
varying highp vec2 qt_TexCoord0;
uniform lowp float hologramFactor;
uniform lowp float wobbleFactor;
highp vec2 wobbleCoords(highp vec2 coords) {
   return coords + wobbleFactor * vec2(0.05 * sin(1.0 * cos(25.0 * (coords.y * coords.y + 0.25 * time))), 0.03 * sin(1.0 * cos(7.0 * (coords.x + 0.23 * time))));
}
highp vec4 sample(vec2 coords) {
   highp vec2 transformed = 100.0 * vec2(coords.x + 0.05 * sin(4.0 * time + 10.0 * coords.y), coords.y);
   highp vec2 mod = transformed - floor(transformed);
   highp vec2 dist = mod - vec2(0.5);
   highp vec4 delta = mix(vec4(1.0), vec4(1.0, 0.7, 0.7, dot(dist, dist)), hologramFactor);
   return delta * texture2D(source, wobbleCoords(coords));
}
void main()
{
    gl_FragColor = sample(qt_TexCoord0);
}

***
QOpenGLShader::link: error: program lacks a fragment shader

shader compilation failed: 
"error: program lacks a fragment shader\n"
QOpenGLShader::link: error: program lacks a fragment shader

QOpenGLShader::compile(Fragment): 0:10(19): error: No precision specified in this scope for type `vec2'

sprayed to stdout without these changes (only appears in 5.9)